### PR TITLE
MIC 2384 | Issue #11 | Issue #31

### DIFF
--- a/ASDKSample/ASDKSample/BuyProductsViewController.swift
+++ b/ASDKSample/ASDKSample/BuyProductsViewController.swift
@@ -139,7 +139,11 @@ class BuyProductsViewController: UIViewController {
 
         var receiptItems: [Item] = []
         products.forEach { product in
-            receiptItems.append(Item(amount: product.price, price: product.price, name: product.name, tax: .vat10))
+            let item = Item(amount: product.price.int64Value * 100,
+                            price: product.price.int64Value * 100,
+                            name: product.name,
+                            tax: .vat10)
+            receiptItems.append(item)
         }
 
         paymentData.receipt = Receipt(shopCode: nil,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## [Unreleased]
 
+### Updated
+* add new Item struct init method to be able to init Item with russian ruble pennies.
+* deprecate Item struct init with NSDecimalNumber type for amount and price
+(MIC-2384/https://github.com/TinkoffCreditSystems/AcquiringSdk_IOS/issues/11/https://github.com/TinkoffCreditSystems/AcquiringSdk_IOS/issues/31)
+
 ## [2.1.4] - 2020-12-29
 
 ### Fixed

--- a/TinkoffASDKCore/TinkoffASDKCore/AcquiringModels.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/AcquiringModels.swift
@@ -675,6 +675,33 @@ public struct Item: Codable {
         supplierInfo = try? container.decode(SupplierInfo.self, forKey: .supplierInfo)
     }
     
+    public init(amount: Int64,
+                price: Int64,
+                name: String,
+                tax: Tax,
+                quantity: Double = 1,
+                paymentObject: PaymentObject? = nil,
+                paymentMethod: PaymentMethod? = nil,
+                ean13: String? = nil,
+                shopCode: String? = nil,
+                measurementUnit: String? = nil,
+                supplierInfo: SupplierInfo? = nil,
+                agentData: AgentData? = nil) {
+        self.amount = amount
+        self.price = price
+        self.name = name
+        self.tax = tax
+        self.quantity = quantity
+        self.paymentObject = paymentObject
+        self.paymentMethod = paymentMethod
+        self.ean13 = ean13
+        self.shopCode = shopCode
+        self.measurementUnit = measurementUnit
+        self.supplierInfo = supplierInfo
+        self.agentData = agentData
+    }
+
+    @available(*, deprecated, message: "Рекомендуется использовать метод, который принимает параметры amount и price в копейках (Int64).")
     public init(amount: NSDecimalNumber,
                 price: NSDecimalNumber,
                 name: String,


### PR DESCRIPTION
add new Item struct init method to be able to init Item with russian ruble pennies.
deprecate Item struct init with NSDecimalNumber type for amount and price