### PR TITLE
MIC 2705 | Network Layer

### DIFF
--- a/TinkoffASDKCore.podspec
+++ b/TinkoffASDKCore.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
 	spec.swift_version = '5.0'
 	spec.ios.deployment_target = '11.0'
 	spec.source = { :git => 'https://github.com/TinkoffCreditSystems/AcquiringSdk_IOS.git', :tag => spec.version }
-	spec.source_files = 'TinkoffASDKCore/TinkoffASDKCore/*.swift'
+	spec.source_files = 'TinkoffASDKCore/TinkoffASDKCore/**/*.swift'
 	spec.resource = "TinkoffASDKCore/TinkoffASDKCore/**/*.{lproj,strings}"
 
 	spec.test_spec 'Tests' do |test_spec|

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultHTTPURLResponseValidator.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultHTTPURLResponseValidator.swift
@@ -1,6 +1,6 @@
 //
 //
-//  NetworkError.swift
+//  DefaultHTTPURLResponseValidator.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -17,10 +17,21 @@
 //  limitations under the License.
 //
 
+
 import Foundation
 
-enum NetworkError: Error {
-    case transportError(Error)
-    case serverError(statusCode: Int, data: Data?)
-    case noData
+struct DefaultHTTPURLResponseValidator: HTTPURLResponseValidator {
+    
+    enum Error: Swift.Error {
+        case failedStatusCode
+    }
+    
+    private let successStatusCodes = 200...299
+    func validate(response: HTTPURLResponse) -> Swift.Result<Void, Swift.Error> {
+        if successStatusCodes.contains(response.statusCode) {
+            return .success(())
+        } else {
+            return .failure(Error.failedStatusCode)
+        }
+    }
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
@@ -42,6 +42,7 @@ final class DefaultNetworkClient: NetworkClient {
     
     // MARK: - NetworkClient
     
+    @discardableResult
     func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void) -> Cancellable {
         do {
             let urlRequest = try requestBuilder.buildURLRequest(baseURL: baseUrl,
@@ -91,14 +92,14 @@ final class DefaultNetworkClient: NetworkClient {
             
             return dataTask
         } catch {
-            handleFailedToBuildeUrlRequest(error: error, completion: completion)
+            handleFailedToBuildUrlRequest(error: error, completion: completion)
             return EmptyCancellable()
         }
     }
 }
 
 private extension DefaultNetworkClient {
-    func handleFailedToBuildeUrlRequest(error: Error, completion: @escaping (NetworkResponse) -> Void) {
+    func handleFailedToBuildUrlRequest(error: Error, completion: @escaping (NetworkResponse) -> Void) {
         let response = NetworkResponse(request: nil,
                                        response: nil,
                                        error: nil,

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
@@ -67,7 +67,6 @@ final class DefaultNetworkClient: NetworkClient {
                 }
                 
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    // TODO: Handle this case
                     result = .failure(NetworkError.noData)
                     return
                 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
@@ -1,6 +1,6 @@
 //
 //
-//  URLSessionNetworkClient.swift
+//  DefaultNetworkClient.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -20,17 +20,17 @@
 
 import Foundation
 
-final class URLSessionNetworkClient: NetworkClient {
-    private let urlSession: URLSession
+final class DefaultNetworkClient: NetworkClient {
+    private let urlRequestPerfomer: URLRequestPerformer
     private let baseUrl: URL
     private let requestBuilder: NetworkClientRequestBuilder
     
     weak var requestAdapter: NetworkRequestAdapter?
     
-    init(urlSession: URLSession,
+    init(urlRequestPerfomer: URLRequestPerformer,
          baseUrl: URL,
          requestBuilder: NetworkClientRequestBuilder) {
-        self.urlSession = urlSession
+        self.urlRequestPerfomer = urlRequestPerfomer
         self.baseUrl = baseUrl
         self.requestBuilder = requestBuilder
     }
@@ -40,9 +40,9 @@ final class URLSessionNetworkClient: NetworkClient {
     func performRequest(_ request: NetworkRequest, completion: @escaping (Result<Data, Error>) -> Void) {
         do {
             let urlRequest = try requestBuilder.buildURLRequest(baseURL: baseUrl,
-                                                            request: request,
-                                                            requestAdapter: requestAdapter)
-            urlSession.dataTask(with: urlRequest) { data, response, error in
+                                                                request: request,
+                                                                requestAdapter: requestAdapter)
+            urlRequestPerfomer.dataTask(with: urlRequest) { data, response, error in
                 if let error = error {
                     completion(.failure(error))
                     return

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
@@ -22,7 +22,7 @@ import Foundation
 
 final class DefaultNetworkClient: NetworkClient {
     private let urlRequestPerfomer: URLRequestPerformer
-    private let baseUrl: URL
+    private let hostProvider: HTTPHostProvider
     private let requestBuilder: NetworkClientRequestBuilder
     private let responseValidator: HTTPURLResponseValidator
     
@@ -31,11 +31,11 @@ final class DefaultNetworkClient: NetworkClient {
     // MARK: - Init
     
     init(urlRequestPerfomer: URLRequestPerformer,
-         baseUrl: URL,
+         hostProvider: HTTPHostProvider,
          requestBuilder: NetworkClientRequestBuilder,
          responseValidator: HTTPURLResponseValidator) {
         self.urlRequestPerfomer = urlRequestPerfomer
-        self.baseUrl = baseUrl
+        self.hostProvider = hostProvider
         self.requestBuilder = requestBuilder
         self.responseValidator = responseValidator
     }
@@ -45,7 +45,7 @@ final class DefaultNetworkClient: NetworkClient {
     @discardableResult
     func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void) -> Cancellable {
         do {
-            let urlRequest = try requestBuilder.buildURLRequest(baseURL: baseUrl,
+            let urlRequest = try requestBuilder.buildURLRequest(baseURL: hostProvider.host,
                                                                 request: request,
                                                                 requestAdapter: requestAdapter)
             

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClient.swift
@@ -49,7 +49,7 @@ final class DefaultNetworkClient: NetworkClient {
                                                                 request: request,
                                                                 requestAdapter: requestAdapter)
             
-            let dataTask = urlRequestPerfomer.dataTask(with: urlRequest) { [responseValidator] data, response, error in
+            let dataTask = urlRequestPerfomer.createDataTask(with: urlRequest) { [responseValidator] data, response, error in
                 let result: Result<Data, Error>
                 
                 defer {

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClientRequestBuilder.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClientRequestBuilder.swift
@@ -1,0 +1,66 @@
+//
+//
+//  DefaultNetworkClientRequestBuilder.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+final class DefaultNetworkClientRequestBuilder: NetworkClientRequestBuilder {
+    
+    enum Error: Swift.Error {
+        case failedToBuildPath
+    }
+    
+    // MARK: - NetworkClientRequestBuilder
+    
+    func buildURLRequest(baseURL: URL, request: NetworkRequest, requestAdapter: NetworkRequestAdapter?) throws -> URLRequest {
+        let endpoint = request.path.joined(separator: "/")
+        guard let url = URL(string: endpoint, relativeTo: baseURL) else {
+            throw Error.failedToBuildPath
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = request.httpMethod.rawValue
+        
+        var bodyParameters = request.bodyParameters
+        var urlParameters = request.urlParameters
+        var headers = request.headers
+        
+        if let requestAdapter = requestAdapter {
+            bodyParameters.merge(requestAdapter.additionalBodyParameters(for: request)) { _, new in new }
+            urlParameters.merge(requestAdapter.additionalURLParameters(for: request)) { _, new in new }
+            headers.merge(requestAdapter.additionalHeaders(for: request)) { _, new in new }
+        }
+        
+        headers.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
+        
+        return urlRequest
+    }
+    
+    // MARK: - Parameters Encoding
+    
+    func encodeURLParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
+        guard !parameters.keys.isEmpty else { return urlRequest }
+        return urlRequest
+    }
+    
+    func encodeJSONParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
+        guard !parameters.keys.isEmpty else { return urlRequest }
+        return urlRequest
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClientRequestBuilder.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/DefaultNetworkClientRequestBuilder.swift
@@ -54,12 +54,12 @@ final class DefaultNetworkClientRequestBuilder: NetworkClientRequestBuilder {
     
     // MARK: - Parameters Encoding
     
-    func encodeURLParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
+    private func encodeURLParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
         guard !parameters.keys.isEmpty else { return urlRequest }
         return urlRequest
     }
     
-    func encodeJSONParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
+    private func encodeJSONParameters(_ parameters: HTTPParameters, urlRequest: URLRequest) throws -> URLRequest {
         guard !parameters.keys.isEmpty else { return urlRequest }
         return urlRequest
     }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/JSONEncoding.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/JSONEncoding.swift
@@ -1,0 +1,59 @@
+//
+//
+//  JSONEncoding.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+struct JSONEncoding: ParametersEncoder {
+    
+    enum Error: Swift.Error {
+        case encodingFailed(error: Swift.Error)
+    }
+    
+    private let options: JSONSerialization.WritingOptions
+    
+    init(options: JSONSerialization.WritingOptions = []) {
+        self.options = options
+    }
+    
+    func encode(_ urlRequest: URLRequest, parameters: HTTPParameters) throws -> URLRequest {
+        guard !parameters.isEmpty else { return urlRequest }
+        
+        do {
+            let data = try JSONSerialization.data(withJSONObject: parameters,
+                                                  options: options)
+            
+            var mutableUrlRequest = urlRequest
+            mutableUrlRequest.httpBody = data
+            
+            if mutableUrlRequest.value(forHTTPHeaderField: .contentType) == nil {
+                mutableUrlRequest.setValue(.applicationJson, forHTTPHeaderField: .contentType)
+            }
+            
+            return mutableUrlRequest
+        } catch {
+            throw Error.encodingFailed(error: error)
+        }
+    }
+}
+
+private extension String {
+    static let contentType = "Content-Type"
+    static let applicationJson = "appplication/json"
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/JSONEncoding.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/JSONEncoding.swift
@@ -55,5 +55,5 @@ struct JSONEncoding: ParametersEncoder {
 
 private extension String {
     static let contentType = "Content-Type"
-    static let applicationJson = "appplication/json"
+    static let applicationJson = "application/json"
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/URLSessionNetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Implementations/URLSessionNetworkClient.swift
@@ -1,0 +1,57 @@
+//
+//
+//  URLSessionNetworkClient.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+final class URLSessionNetworkClient: NetworkClient {
+    private let urlSession: URLSession
+    private let baseUrl: URL
+    private let requestBuilder: NetworkClientRequestBuilder
+    
+    weak var requestAdapter: NetworkRequestAdapter?
+    
+    init(urlSession: URLSession,
+         baseUrl: URL,
+         requestBuilder: NetworkClientRequestBuilder) {
+        self.urlSession = urlSession
+        self.baseUrl = baseUrl
+        self.requestBuilder = requestBuilder
+    }
+    
+    // MARK: NetworkClient
+    
+    func performRequest(_ request: NetworkRequest, completion: @escaping (Result<Data, Error>) -> Void) {
+        do {
+            let urlRequest = try requestBuilder.buildURLRequest(baseURL: baseUrl,
+                                                            request: request,
+                                                            requestAdapter: requestAdapter)
+            urlSession.dataTask(with: urlRequest) { data, response, error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+                
+                completion(.success(data ?? Data()))
+            }.resume()
+        } catch {
+            completion(.failure(error))
+        }
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/HTTPHostProvider.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/HTTPHostProvider.swift
@@ -1,0 +1,25 @@
+//
+//
+//  HTTPHostProvider.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+protocol HTTPHostProvider {
+    var host: URL { get }
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/HTTPURLResponseValidator.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/HTTPURLResponseValidator.swift
@@ -1,6 +1,6 @@
 //
 //
-//  NetworkError.swift
+//  HTTPURLResponseValidator.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -17,10 +17,9 @@
 //  limitations under the License.
 //
 
+
 import Foundation
 
-enum NetworkError: Error {
-    case transportError(Error)
-    case serverError(statusCode: Int, data: Data?)
-    case noData
+protocol HTTPURLResponseValidator {
+    func validate(response: HTTPURLResponse) -> Swift.Result<Void, Error>
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClient.swift
@@ -21,5 +21,5 @@
 import Foundation
 
 protocol NetworkClient {
-    func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void)
+    func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void) -> Cancellable
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClient.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClient.swift
@@ -1,0 +1,25 @@
+//
+//
+//  NetworkClient.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+protocol NetworkClient {
+    func performRequest(_ request: NetworkRequest, completion: @escaping (Result<Data, Error>) -> Void)
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClientRequestBuilder.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkClientRequestBuilder.swift
@@ -1,0 +1,25 @@
+//
+//
+//  NetworkClientRequestBuilder.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+protocol NetworkClientRequestBuilder {
+    func buildURLRequest(baseURL: URL, request: NetworkRequest, requestAdapter: NetworkRequestAdapter?) throws -> URLRequest
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkDataTask.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkDataTask.swift
@@ -1,6 +1,6 @@
 //
 //
-//  URLRequestPerformer.swift
+//  NetworkDataTask.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -20,7 +20,7 @@
 
 import Foundation
 
-protocol URLRequestPerformer {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
+protocol NetworkDataTask {
+    func resume()
+    func cancel()
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkDataTask.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkDataTask.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-protocol NetworkDataTask {
+protocol NetworkDataTask: Cancellable {
     func resume()
     func cancel()
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
@@ -22,19 +22,15 @@ import Foundation
 
 protocol NetworkRequestAdapter: AnyObject {
     func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders
-    func additionalBodyParameters(for request: NetworkRequest) -> HTTPHeaders
-    func additionalURLParameters(for request: NetworkRequest) -> HTTPHeaders
+    func additionalParameters(for request: NetworkRequest) -> HTTPParameters
 }
 
 extension NetworkRequestAdapter {
     func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders {
-        return [:]
+        [:]
     }
-    func additionalBodyParameters(for request: NetworkRequest) -> HTTPHeaders {
-        return [:]
-    }
-    func additionalURLParameters(for request: NetworkRequest) -> HTTPHeaders {
-        return [:]
+    func additionalParameters(for request: NetworkRequest) -> HTTPHeaders {
+        [:]
     }
 }
 

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
@@ -29,7 +29,7 @@ extension NetworkRequestAdapter {
     func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders {
         [:]
     }
-    func additionalParameters(for request: NetworkRequest) -> HTTPHeaders {
+    func additionalParameters(for request: NetworkRequest) -> HTTPParameters {
         [:]
     }
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/NetworkRequestAdapter.swift
@@ -1,0 +1,40 @@
+//
+//
+//  NetworkRequestAdapter.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+protocol NetworkRequestAdapter: AnyObject {
+    func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders
+    func additionalBodyParameters(for request: NetworkRequest) -> HTTPHeaders
+    func additionalURLParameters(for request: NetworkRequest) -> HTTPHeaders
+}
+
+extension NetworkRequestAdapter {
+    func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders {
+        return [:]
+    }
+    func additionalBodyParameters(for request: NetworkRequest) -> HTTPHeaders {
+        return [:]
+    }
+    func additionalURLParameters(for request: NetworkRequest) -> HTTPHeaders {
+        return [:]
+    }
+}
+

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/ParametersEncoder.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/ParametersEncoder.swift
@@ -1,6 +1,6 @@
 //
 //
-//  TestsNetworkRequest.swift
+//  ParametersEncoder.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -17,21 +17,9 @@
 //  limitations under the License.
 //
 
-@testable import TinkoffASDKCore
 
-struct TestsNetworkRequest: NetworkRequest {
-    let path: [String]
-    let httpMethod: HTTPMethod
-    let parameters: HTTPParameters
-    let headers: HTTPHeaders
-    
-    init(path: [String],
-         httpMethod: HTTPMethod,
-         parameters: HTTPParameters = [:],
-         headers: HTTPHeaders = [:]) {
-        self.path = path
-        self.httpMethod = httpMethod
-        self.parameters = parameters
-        self.headers = headers
-    }
+import Foundation
+
+protocol ParametersEncoder {
+    func encode(_ urlRequest: URLRequest, parameters: HTTPParameters) throws -> URLRequest
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/URLRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/URLRequestPerformer.swift
@@ -1,0 +1,26 @@
+//
+//
+//  URLRequestPerformer.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+protocol URLRequestPerformer {
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/URLRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/Interfaces/URLRequestPerformer.swift
@@ -21,6 +21,6 @@
 import Foundation
 
 protocol URLRequestPerformer {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
+    func createDataTask(with request: URLRequest,
+                        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkError.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkError.swift
@@ -1,0 +1,26 @@
+//
+//
+//  NetworkError.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case transportError(Error)
+    case serverError(statusCoder: Int, data: Data?)
+    case noData
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkRequest.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkRequest.swift
@@ -25,19 +25,24 @@ enum HTTPMethod: String {
     case post = "POST"
 }
 
+enum HTTPParametersEncoding {
+    case json
+    case url
+}
+
 typealias HTTPParameters = [String: Any]
 typealias HTTPHeaders = [String: String]
 
 protocol NetworkRequest {
     var path: [String] { get }
     var httpMethod: HTTPMethod { get }
-    var urlParameters: HTTPParameters { get }
-    var bodyParameters: HTTPParameters { get }
+    var parameters: HTTPParameters { get }
+    var parametersEncoding: HTTPParametersEncoding { get }
     var headers: HTTPHeaders { get }
 }
 
 extension NetworkRequest {
-    var urlParameters: HTTPParameters { return [:] }
-    var bodyParameters: HTTPParameters { return [:] }
-    var headers: HTTPHeaders { return [:] }
+    var parameters: HTTPParameters { [:] }
+    var parametersEncoding: HTTPParametersEncoding { .json }
+    var headers: HTTPHeaders { [:] }
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkRequest.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkRequest.swift
@@ -1,0 +1,43 @@
+//
+//
+//  NetworkRequest.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+}
+
+typealias HTTPParameters = [String: Any]
+typealias HTTPHeaders = [String: String]
+
+protocol NetworkRequest {
+    var path: [String] { get }
+    var httpMethod: HTTPMethod { get }
+    var urlParameters: HTTPParameters { get }
+    var bodyParameters: HTTPParameters { get }
+    var headers: HTTPHeaders { get }
+}
+
+extension NetworkRequest {
+    var urlParameters: HTTPParameters { return [:] }
+    var bodyParameters: HTTPParameters { return [:] }
+    var headers: HTTPHeaders { return [:] }
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkResponse.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/NetworkResponse.swift
@@ -1,6 +1,6 @@
 //
 //
-//  NetworkClient.swift
+//  NetworkResponse.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -20,6 +20,10 @@
 
 import Foundation
 
-protocol NetworkClient {
-    func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void)
+struct NetworkResponse {
+    let request: URLRequest?
+    let response: HTTPURLResponse?
+    let error: Error?
+    let data: Data?
+    let result: Result<Data, Error>
 }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/URL+HTTPHostProvider.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/URL+HTTPHostProvider.swift
@@ -1,0 +1,25 @@
+//
+//
+//  URL+HostProvider.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+extension URL: HTTPHostProvider {
+    var host: URL { self }
+}

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
@@ -1,0 +1,24 @@
+//
+//
+//  URLSession+URLRequestPerformer.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+extension URLSession: URLRequestPerformer {}
+

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
@@ -20,5 +20,10 @@
 
 import Foundation
 
-extension URLSession: URLRequestPerformer {}
+extension URLSession: URLRequestPerformer {
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
+        let urlSessionDataTask: URLSessionDataTask = dataTask(with: request, completionHandler: completionHandler)
+        return urlSessionDataTask
+    }
+}
 

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/URLSession+URLRequestPerformer.swift
@@ -21,7 +21,7 @@
 import Foundation
 
 extension URLSession: URLRequestPerformer {
-    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
+    func createDataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
         let urlSessionDataTask: URLSessionDataTask = dataTask(with: request, completionHandler: completionHandler)
         return urlSessionDataTask
     }

--- a/TinkoffASDKCore/TinkoffASDKCore/Network/URLSessionDataTask+NetworkDataTask.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Network/URLSessionDataTask+NetworkDataTask.swift
@@ -1,6 +1,6 @@
 //
 //
-//  URLRequestPerformer.swift
+//  URLSessionDataTask+NetworkDataTask.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -20,7 +20,4 @@
 
 import Foundation
 
-protocol URLRequestPerformer {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
-}
+extension URLSessionDataTask: NetworkDataTask {}

--- a/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
@@ -115,7 +115,7 @@ final class AcquaringNetworkTransport: NetworkTransport {
     private(set) lazy var complete3DSMethodV2URL: URL = {
         self.urlDomain.appendingPathComponent(self.apiPathV2).appendingPathComponent("Complete3DSMethodv2")
     }()
-
+    
     private func setDefaultHTTPHeaders(for request: inout URLRequest) {
         request.setValue("application/x-www-form-urlencoded; charset=utf-8; gzip,deflate;", forHTTPHeaderField: "Content-Type")
         request.setValue("text/html,application/xhtml+xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")

--- a/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
@@ -212,7 +212,7 @@ final class AcquaringNetworkTransport: NetworkTransport {
 
         let responseLoger = logger
 
-        let task = session.dataTask(with: request) { data, response, networkError in
+        let task: URLSessionDataTask = session.dataTask(with: request) { data, response, networkError in
             if let error = networkError {
                 responseLoger?.print("🛬 End request: \(request.description), with: \(error.localizedDescription)")
                 return completionHandler(.failure(error))

--- a/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
@@ -267,7 +267,7 @@ final class AcquaringNetworkTransport: NetworkTransport {
                 if let message = acquiringResponse.errorMessage {
                     errorMessage = message
                 }
-
+                
                 if let details = acquiringResponse.errorDetails, details.isEmpty == false {
                     errorMessage.append(contentsOf: " ")
                     errorMessage.append(contentsOf: details)

--- a/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/NetworkTransport.swift
@@ -212,7 +212,7 @@ final class AcquaringNetworkTransport: NetworkTransport {
 
         let responseLoger = logger
 
-        let task: URLSessionDataTask = session.dataTask(with: request) { data, response, networkError in
+        let task = session.dataTask(with: request) { data, response, networkError in
             if let error = networkError {
                 responseLoger?.print("🛬 End request: \(request.description), with: \(error.localizedDescription)")
                 return completionHandler(.failure(error))

--- a/TinkoffASDKCore/TinkoffASDKCore/Utils.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/Utils.swift
@@ -74,7 +74,7 @@ struct DeviceInfo {
 
 // MARK: URL Session Conformance
 
-public protocol Cancellable: class {
+public protocol Cancellable {
     func cancel()
 }
 

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/EmptyNetworkDataTask.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/EmptyNetworkDataTask.swift
@@ -1,6 +1,6 @@
 //
 //
-//  URLRequestPerformer.swift
+//  EmptyNetworkDataTask.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -17,10 +17,10 @@
 //  limitations under the License.
 //
 
-
+@testable import TinkoffASDKCore
 import Foundation
 
-protocol URLRequestPerformer {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
+struct EmptyNetworkDataTask: NetworkDataTask {
+    func resume() {}
+    func cancel() {}
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockHTTPURLResponseValidator.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockHTTPURLResponseValidator.swift
@@ -1,6 +1,6 @@
 //
 //
-//  NetworkClient.swift
+//  MockHTTPURLResponseValidator.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -18,9 +18,15 @@
 //
 
 
-import Foundation
+@testable import TinkoffASDKCore
 
-protocol NetworkClient {
-    @discardableResult
-    func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void) -> Cancellable
+final class MockHTTPURLResponseValidator: HTTPURLResponseValidator {
+    
+    var validateMethodCalled = true
+    var result: Result<Void, Error> = .success(())
+    
+    func validate(response: HTTPURLResponse) -> Result<Void, Error> {
+        validateMethodCalled = true
+        return result
+    }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockNetworkRequestAdapter.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockNetworkRequestAdapter.swift
@@ -1,6 +1,6 @@
 //
 //
-//  TestsNetworkRequest.swift
+//  MockNetworkRequestAdapter.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -17,24 +17,25 @@
 //  limitations under the License.
 //
 
+
 @testable import TinkoffASDKCore
 
-struct TestsNetworkRequest: NetworkRequest {
-    let path: [String]
-    let httpMethod: HTTPMethod
-    let parameters: HTTPParameters
-    let parametersEncoding: HTTPParametersEncoding
-    let headers: HTTPHeaders
+final class MockNetworkRequestAdapter: NetworkRequestAdapter {
+
+    var isAdditionalHeadersMethodCalled = false
+    var isAdditionalParametersMethodCalled = false
     
-    init(path: [String],
-         httpMethod: HTTPMethod,
-         parameters: HTTPParameters = [:],
-         parametersEncoding: HTTPParametersEncoding = .json,
-         headers: HTTPHeaders = [:]) {
-        self.path = path
-        self.httpMethod = httpMethod
-        self.parameters = parameters
-        self.parametersEncoding = parametersEncoding
-        self.headers = headers
+    var additionalHeaders: HTTPHeaders = [:]
+    var additionalParameters: HTTPParameters = [:]
+    
+    func additionalHeaders(for request: NetworkRequest) -> HTTPHeaders {
+        isAdditionalHeadersMethodCalled = true
+        return additionalHeaders
+    }
+    
+    func additionalParameters(for request: NetworkRequest) -> HTTPParameters {
+        isAdditionalParametersMethodCalled = true
+        return additionalParameters
     }
 }
+

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestBuilder.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestBuilder.swift
@@ -1,6 +1,6 @@
 //
 //
-//  NetworkClient.swift
+//  MockRequestBuilder.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -18,9 +18,16 @@
 //
 
 
-import Foundation
+@testable import TinkoffASDKCore
 
-protocol NetworkClient {
-    @discardableResult
-    func performRequest(_ request: NetworkRequest, completion: @escaping (NetworkResponse) -> Void) -> Cancellable
+final class MockRequestBuilder: NetworkClientRequestBuilder {
+    
+    var buildURLRequestMethodCalled = false
+    
+    func buildURLRequest(baseURL: URL,
+                         request: NetworkRequest,
+                         requestAdapter: NetworkRequestAdapter?) throws -> URLRequest {
+        self.buildURLRequestMethodCalled = true
+        return URLRequest(url: baseURL)
+    }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestPerformer.swift
@@ -1,6 +1,6 @@
 //
 //
-//  URLRequestPerformer.swift
+//  MockRequestPerformer.swift
 //
 //  Copyright (c) 2021 Tinkoff Bank
 //
@@ -18,9 +18,22 @@
 //
 
 
+@testable import TinkoffASDKCore
 import Foundation
 
-protocol URLRequestPerformer {
+final class MockRequestPerformer: URLRequestPerformer {
+    var dataTaskMethodCalled = false
+    var request: URLRequest?
+    var data: Data?
+    var urlResponse: URLResponse?
+    var error: Error?
+    
     func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
+        self.dataTaskMethodCalled = true
+        self.request = request
+        
+        completionHandler(data, urlResponse, error)
+        return EmptyNetworkDataTask()
+    }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestPerformer.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/MockRequestPerformer.swift
@@ -28,8 +28,8 @@ final class MockRequestPerformer: URLRequestPerformer {
     var urlResponse: URLResponse?
     var error: Error?
     
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
+    func createDataTask(with request: URLRequest,
+                        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkDataTask {
         self.dataTaskMethodCalled = true
         self.request = request
         

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/TestsNetworkRequest.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Infrastructure/TestsNetworkRequest.swift
@@ -1,0 +1,40 @@
+//
+//
+//  TestsNetworkRequest.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import TinkoffASDKCore
+
+struct TestsNetworkRequest: NetworkRequest {
+    let path: [String]
+    let httpMethod: HTTPMethod
+    let urlParameters: HTTPParameters
+    let bodyParameters: HTTPParameters
+    let headers: HTTPHeaders
+    
+    init(path: [String],
+         httpMethod: HTTPMethod,
+         urlParameters: HTTPParameters = [:],
+         bodyParameters: HTTPParameters = [:],
+         headers: HTTPHeaders = [:]) {
+        self.path = path
+        self.httpMethod = httpMethod
+        self.urlParameters = urlParameters
+        self.bodyParameters = bodyParameters
+        self.headers = headers
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultHTTPURLResponseValidatorTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultHTTPURLResponseValidatorTests.swift
@@ -1,0 +1,87 @@
+//
+//
+//  DefaultHTTPURLResponseValidatorTests.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+@testable import TinkoffASDKCore
+import XCTest
+
+class DefaultHTTPURLResponseValidatorTests: XCTestCase {
+    
+    let url = URL(string: "https://tinkoff.ru")!
+    let httpVersion = "HTTP/1.1"
+    
+    let validator = DefaultHTTPURLResponseValidator()
+    
+    func testValidIfStatusCode200() throws {
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 200,
+                                       httpVersion: httpVersion,
+                                       headerFields: nil)!
+        
+        XCTAssertNoThrow(try validator.validate(response: response).get())
+    }
+    
+    func testValidIfStatusCode250() throws {
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 250,
+                                       httpVersion: httpVersion,
+                                       headerFields: nil)!
+        
+        XCTAssertNoThrow(try validator.validate(response: response).get())
+    }
+    
+    func testValidIfStatusCode299() throws {
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 299,
+                                       httpVersion: httpVersion,
+                                       headerFields: nil)!
+        
+        XCTAssertNoThrow(try validator.validate(response: response).get())
+    }
+    
+    func testInvalidIfStatusCode400() throws {
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 400,
+                                       httpVersion: httpVersion,
+                                       headerFields: nil)!
+        
+        XCTAssertThrowsError(try validator.validate(response: response).get(), "") { error in
+            guard let defaultHTTPURLResponseValidatorError = error as? DefaultHTTPURLResponseValidator.Error,
+                  defaultHTTPURLResponseValidatorError == .failedStatusCode else {
+                XCTFail("response with 400 status code must produce error DefaultHTTPURLResponseValidator.failedStatusCode")
+                return
+            }
+        }
+    }
+    
+    func testInvalidIfStatusCode500() throws {
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 400,
+                                       httpVersion: httpVersion,
+                                       headerFields: nil)!
+        
+        XCTAssertThrowsError(try validator.validate(response: response).get(), "") { error in
+            guard let defaultHTTPURLResponseValidatorError = error as? DefaultHTTPURLResponseValidator.Error,
+                  defaultHTTPURLResponseValidatorError == .failedStatusCode else {
+                XCTFail("response with 400 status code must produce error DefaultHTTPURLResponseValidator.failedStatusCode")
+                return
+            }
+        }
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
@@ -26,7 +26,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
     let url = URL(string: "https://tinkoff.ru")!
     let urlRequestPerformer = MockRequestPerformer()
     lazy var networkClient = DefaultNetworkClient(urlRequestPerfomer: urlRequestPerformer,
-                                                  baseUrl: url,
+                                                  hostProvider: url,
                                                   requestBuilder: DefaultNetworkClientRequestBuilder(),
                                                   responseValidator: DefaultHTTPURLResponseValidator())
     

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
@@ -23,6 +23,8 @@ import XCTest
 
 class DefaultNetworkClientIntegrationTests: XCTestCase {
     
+    let networkRequestExpectationTimeout: TimeInterval = 5
+    
     let url = URL(string: "https://tinkoff.ru")!
     let urlRequestPerformer = MockRequestPerformer()
     lazy var networkClient = DefaultNetworkClient(urlRequestPerfomer: urlRequestPerformer,
@@ -41,19 +43,29 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
     func testIfNetworkClientCallsUrlRequestPerformerDataTaskMethod() {
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { [urlRequestPerformer] _ in
             XCTAssertTrue(urlRequestPerformer.dataTaskMethodCalled, "urlRequestPerformer's dataTask method must be called when networkClient perform request")
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testIfErrorResponseAndDataAreNilInNetworkClientResultIfBothWereNotPassedFromRequestPerformer() {
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             XCTAssertNil(response.data)
             XCTAssertNil(response.response)
             XCTAssertNil(response.error)
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testIfErrorResponseAndDataAreNotNilInNetworkClientResultIfBothWerePassedFromRequestPerformer() {
@@ -72,11 +84,15 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             XCTAssertNotNil(response.data)
             XCTAssertNotNil(response.response)
             XCTAssertNotNil(response.error)
+            
+            requestExpectation.fulfill()
         }
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testTransportErrorIfErrorNotNil() {
@@ -85,6 +101,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             switch response.result {
             case .failure(let resultError):
@@ -98,7 +115,11 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
             case .success:
                 XCTFail()
             }
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testServerErrorWith401StatusCodeAndWithoutData() {
@@ -108,6 +129,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             switch response.result {
             case .failure(let resultError):
@@ -122,7 +144,11 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
             case .success:
                 XCTFail()
             }
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testServerErrorWith401StatusCodeAndWithData() {
@@ -135,6 +161,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             switch response.result {
             case .failure(let resultError):
@@ -149,7 +176,11 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
             case .success:
                 XCTFail()
             }
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testNoDataErrorWith200StatusCodeAndNoDataFromPerformer() {
@@ -160,6 +191,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             switch response.result {
             case .failure(let resultError):
@@ -171,7 +203,11 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
             case .success:
                 XCTFail()
             }
+            
+            requestExpectation.fulfill()
         }
+        
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
     
     func testDataReturnedInResponse() {
@@ -184,6 +220,7 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
         
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         
+        let requestExpectation = XCTestExpectation()
         networkClient.performRequest(request) { response in
             switch response.result {
             case .failure:
@@ -192,6 +229,9 @@ class DefaultNetworkClientIntegrationTests: XCTestCase {
                 XCTAssertNotNil(data)
                 XCTAssertEqual(data, performerData)
             }
+            
+            requestExpectation.fulfill()
         }
+        wait(for: [requestExpectation], timeout: networkRequestExpectationTimeout)
     }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientIntegrationTests.swift
@@ -1,0 +1,197 @@
+//
+//
+//  DefaultNetworkClientIntegrationTests.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+@testable import TinkoffASDKCore
+import XCTest
+
+class DefaultNetworkClientIntegrationTests: XCTestCase {
+    
+    let url = URL(string: "https://tinkoff.ru")!
+    let urlRequestPerformer = MockRequestPerformer()
+    lazy var networkClient = DefaultNetworkClient(urlRequestPerfomer: urlRequestPerformer,
+                                                  baseUrl: url,
+                                                  requestBuilder: DefaultNetworkClientRequestBuilder(),
+                                                  responseValidator: DefaultHTTPURLResponseValidator())
+    
+    override func setUp() {
+        urlRequestPerformer.request = nil
+        urlRequestPerformer.data = nil
+        urlRequestPerformer.urlResponse = nil
+        urlRequestPerformer.error = nil
+        urlRequestPerformer.dataTaskMethodCalled = false
+    }
+    
+    func testIfNetworkClientCallsUrlRequestPerformerDataTaskMethod() {
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { [urlRequestPerformer] _ in
+            XCTAssertTrue(urlRequestPerformer.dataTaskMethodCalled, "urlRequestPerformer's dataTask method must be called when networkClient perform request")
+        }
+    }
+    
+    func testIfErrorResponseAndDataAreNilInNetworkClientResultIfBothWereNotPassedFromRequestPerformer() {
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            XCTAssertNil(response.data)
+            XCTAssertNil(response.response)
+            XCTAssertNil(response.error)
+        }
+    }
+    
+    func testIfErrorResponseAndDataAreNotNilInNetworkClientResultIfBothWerePassedFromRequestPerformer() {
+        let error = NSError(domain: "ru.tinkoff.testError", code: 666, userInfo: nil)
+        
+        let data = "some string".data(using: .utf8)
+        
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 200,
+                                       httpVersion: "HTTP/1.1",
+                                       headerFields: nil)
+        
+        urlRequestPerformer.error = error
+        urlRequestPerformer.data = data
+        urlRequestPerformer.urlResponse = response
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            XCTAssertNotNil(response.data)
+            XCTAssertNotNil(response.response)
+            XCTAssertNotNil(response.error)
+        }
+    }
+    
+    func testTransportErrorIfErrorNotNil() {
+        let error = NSError(domain: "ru.tinkoff.testError", code: 666, userInfo: nil)
+        urlRequestPerformer.error = error
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            switch response.result {
+            case .failure(let resultError):
+                guard let networkError = resultError as? NetworkError,
+                      case .transportError(let underlyingError) = networkError else {
+                    XCTFail()
+                    return
+                }
+                
+                XCTAssertEqual(underlyingError as NSError, error)
+            case .success:
+                XCTFail()
+            }
+        }
+    }
+    
+    func testServerErrorWith401StatusCodeAndWithoutData() {
+        let errorStatusCode = 401
+        let response = HTTPURLResponse(url: url, statusCode: errorStatusCode, httpVersion: "HTTP/1.1", headerFields: nil)
+        urlRequestPerformer.urlResponse = response
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            switch response.result {
+            case .failure(let resultError):
+                guard let networkError = resultError as? NetworkError,
+                      case let .serverError(statusCode, data) = networkError else {
+                    XCTFail()
+                    return
+                }
+                
+                XCTAssertEqual(statusCode, errorStatusCode)
+                XCTAssertNil(data)
+            case .success:
+                XCTFail()
+            }
+        }
+    }
+    
+    func testServerErrorWith401StatusCodeAndWithData() {
+        let errorStatusCode = 401
+        let response = HTTPURLResponse(url: url, statusCode: errorStatusCode, httpVersion: "HTTP/1.1", headerFields: nil)
+        let data = "some string".data(using: .utf8)
+        
+        urlRequestPerformer.urlResponse = response
+        urlRequestPerformer.data = data
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            switch response.result {
+            case .failure(let resultError):
+                guard let networkError = resultError as? NetworkError,
+                      case let .serverError(statusCode, data) = networkError else {
+                    XCTFail()
+                    return
+                }
+                
+                XCTAssertEqual(statusCode, errorStatusCode)
+                XCTAssertNotNil(data)
+            case .success:
+                XCTFail()
+            }
+        }
+    }
+    
+    func testNoDataErrorWith200StatusCodeAndNoDataFromPerformer() {
+        let successStatusCode = 200
+        let response = HTTPURLResponse(url: url, statusCode: successStatusCode, httpVersion: "HTTP/1.1", headerFields: nil)
+    
+        urlRequestPerformer.urlResponse = response
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            switch response.result {
+            case .failure(let resultError):
+                guard let networkError = resultError as? NetworkError,
+                      case .noData = networkError else {
+                    XCTFail()
+                    return
+                }
+            case .success:
+                XCTFail()
+            }
+        }
+    }
+    
+    func testDataReturnedInResponse() {
+        let successStatusCode = 200
+        let response = HTTPURLResponse(url: url, statusCode: successStatusCode, httpVersion: "HTTP/1.1", headerFields: nil)
+        let performerData = "some string".data(using: .utf8)
+        
+        urlRequestPerformer.urlResponse = response
+        urlRequestPerformer.data = performerData
+        
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        
+        networkClient.performRequest(request) { response in
+            switch response.result {
+            case .failure:
+                XCTFail()
+            case .success(let data):
+                XCTAssertNotNil(data)
+                XCTAssertEqual(data, performerData)
+            }
+        }
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
@@ -36,93 +36,59 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
         XCTAssertThrowsError(try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil))
     }
 
-    func testBuildCorrectUrlWithOneItemPath() {
+    func testBuildCorrectUrlWithOneItemPath() throws {
         let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
         let resultURLString = "https://tinkoff.ru/test"
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
-            XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+        XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
     }
     
-    func testBuildCorrectUrlWithThreeItemsPath() {
+    func testBuildCorrectUrlWithThreeItemsPath() throws {
         let request = TestsNetworkRequest(path: ["test", "url", "builder"], httpMethod: .get)
         let resultURLString = "https://tinkoff.ru/test/url/builder"
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
-            XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+        XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
     }
     
-    func testBuilderSetHeadersFromRequest() {
+    func testBuilderSetHeadersFromRequest() throws {
         let headers = ["headerKey": "headerValue"]
         let request = TestsNetworkRequest(path: ["test"],
                                           httpMethod: .get,
                                           headers: headers)
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
-            XCTAssertEqual(headers, urlRequest.allHTTPHeaderFields)
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+        XCTAssertEqual(headers, urlRequest.allHTTPHeaderFields)
     }
     
-    func testJSONParametersEncoding() {
+    func testJSONParametersEncoding() throws {
         let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
         
         let request = TestsNetworkRequest(path: ["test"],
                                           httpMethod: .post,
                                           parameters: parameters)
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
-            
-            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
-                                                                       options: []) as? [String: Any]
-            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
-            
-            XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
-                           NSDictionary(dictionary: parameters))
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: nil)
+        let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                   options: []) as? [String: Any]
+        XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
+                       NSDictionary(dictionary: parameters))
     }
     
-    func testJSONParametersEncodingSetCorrectContentTypeIfNotSetBefore() {
+    func testJSONParametersEncodingSetCorrectContentTypeIfNotSetBefore() throws {
         let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
         
         let request = TestsNetworkRequest(path: ["test"],
                                           httpMethod: .post,
                                           parameters: parameters)
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
-            
-            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
-                                                                       options: []) as? [String: Any]
-            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
-            
-            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
-            
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: nil)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
     
-    func testJSONParametersEncodingDoesntSetContentTypeIfSetBefore() {
+    func testJSONParametersEncodingDoesntSetContentTypeIfSetBefore() throws {
         let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
         
         let request = TestsNetworkRequest(path: ["test"],
@@ -130,44 +96,29 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
                                           parameters: parameters,
                                           headers: ["Content-Type": "anything"])
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: nil)
-            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
-            
-            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
-                                                                       options: []) as? [String: Any]
-            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
-            
-            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "anything")
-            
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: nil)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "anything")
     }
     
-    func testBuilderCallsNetworkRequestAdapterParametersAndHeadersMethod() {
+    func testBuilderCallsNetworkRequestAdapterParametersAndHeadersMethod() throws {
         let mockRequestAdapter = MockNetworkRequestAdapter()
         
         let request = TestsNetworkRequest(path: ["test"],
                                           httpMethod: .post)
         
-        do {
-            _ = try builder.buildURLRequest(baseURL: baseURL,
+        _ = try builder.buildURLRequest(baseURL: baseURL,
                                         request: request,
                                         requestAdapter: mockRequestAdapter)
-            
-            XCTAssertTrue(mockRequestAdapter.isAdditionalHeadersMethodCalled,
-                          "additionalHeaders(for request: NetworkRequest) method must be called")
-            XCTAssertTrue(mockRequestAdapter.isAdditionalParametersMethodCalled,
-                          "additionalParameters(for request: NetworkRequest) method must be called")
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        
+        XCTAssertTrue(mockRequestAdapter.isAdditionalHeadersMethodCalled,
+                      "additionalHeaders(for request: NetworkRequest) method must be called")
+        XCTAssertTrue(mockRequestAdapter.isAdditionalParametersMethodCalled,
+                      "additionalParameters(for request: NetworkRequest) method must be called")
     }
     
-    func testBuilderAddAdditinalHeadersToEmptyRequestHeadersFromNetworkRequestAdapter() {
+    func testBuilderAddAdditinalHeadersToEmptyRequestHeadersFromNetworkRequestAdapter() throws {
         let mockRequestAdapter = MockNetworkRequestAdapter()
         let additionalHeaders = ["headerKey1": "headerValue1",
                                  "headerKey2": "headerValue2"]
@@ -176,18 +127,14 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
         let request = TestsNetworkRequest(path: ["test"],
                                           httpMethod: .post)
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: mockRequestAdapter)
-            
-            XCTAssertEqual(urlRequest.allHTTPHeaderFields, additionalHeaders)
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: mockRequestAdapter)
+        
+        XCTAssertEqual(urlRequest.allHTTPHeaderFields, additionalHeaders)
     }
     
-    func testBuilderAddAdditinalHeadersToRequestHeadersFromNetworkRequestAdapter() {
+    func testBuilderAddAdditinalHeadersToRequestHeadersFromNetworkRequestAdapter() throws {
         let mockRequestAdapter = MockNetworkRequestAdapter()
         let additionalHeaders = ["headerKey1": "headerValue1",
                                  "headerKey2": "headerValue2"]
@@ -203,18 +150,14 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
                              "headerKey3": "headerValue3",
                              "Content-Type": "application/json"]
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: mockRequestAdapter)
-            
-            XCTAssertEqual(urlRequest.allHTTPHeaderFields, resultHeaders)
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: mockRequestAdapter)
+        
+        XCTAssertEqual(urlRequest.allHTTPHeaderFields, resultHeaders)
     }
     
-    func testBuilderAddAdditinalParametersToRequestFromNetworkRequestAdapter() {
+    func testBuilderAddAdditinalParametersToRequestFromNetworkRequestAdapter() throws {
         let mockRequestAdapter = MockNetworkRequestAdapter()
         let additionalParameters: HTTPParameters = ["additionalParamKey1": "additionalParamValue1",
                                                     "additionalParamKey2": false]
@@ -233,20 +176,13 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
             "additionalParamKey2": false
         ]
         
-        do {
-            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
-                                                         request: request,
-                                                         requestAdapter: mockRequestAdapter)
-            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
-            
-            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
-                                                                       options: []) as? [String: Any]
-            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
-            
-            XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
-                           NSDictionary(dictionary: resultParameters))
-        } catch {
-            XCTFail("URLRequest build failed with: \(error)")
-        }
+        let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                     request: request,
+                                                     requestAdapter: mockRequestAdapter)
+        
+        let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                   options: []) as? [String: Any]
+        XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
+                       NSDictionary(dictionary: resultParameters))
     }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
@@ -59,4 +59,28 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
             XCTFail("URLRequest build failed with: \(error)")
         }
     }
+    
+    func testJSONParametersEncoding() {
+        let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post,
+                                          parameters: parameters)
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
+            
+            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                       options: []) as? [String: Any]
+            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
+            
+            XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
+                           NSDictionary(dictionary: parameters))
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
 }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
@@ -60,6 +60,20 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
         }
     }
     
+    func testBuilderSetHeadersFromRequest() {
+        let headers = ["headerKey": "headerValue"]
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .get,
+                                          headers: headers)
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
+            XCTAssertEqual(headers, urlRequest.allHTTPHeaderFields)
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
     func testJSONParametersEncoding() {
         let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
         
@@ -79,6 +93,158 @@ class DefaultNetworkClientRequestBuilderTests: XCTestCase {
             
             XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
                            NSDictionary(dictionary: parameters))
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testJSONParametersEncodingSetCorrectContentTypeIfNotSetBefore() {
+        let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post,
+                                          parameters: parameters)
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
+            
+            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                       options: []) as? [String: Any]
+            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
+            
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testJSONParametersEncodingDoesntSetContentTypeIfSetBefore() {
+        let parameters: [String: Any] = ["param1": true, "param2": "value2", "param3": 10]
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post,
+                                          parameters: parameters,
+                                          headers: ["Content-Type": "anything"])
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
+            
+            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                       options: []) as? [String: Any]
+            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
+            
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "anything")
+            
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testBuilderCallsNetworkRequestAdapterParametersAndHeadersMethod() {
+        let mockRequestAdapter = MockNetworkRequestAdapter()
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post)
+        
+        do {
+            _ = try builder.buildURLRequest(baseURL: baseURL,
+                                        request: request,
+                                        requestAdapter: mockRequestAdapter)
+            
+            XCTAssertTrue(mockRequestAdapter.isAdditionalHeadersMethodCalled,
+                          "additionalHeaders(for request: NetworkRequest) method must be called")
+            XCTAssertTrue(mockRequestAdapter.isAdditionalParametersMethodCalled,
+                          "additionalParameters(for request: NetworkRequest) method must be called")
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testBuilderAddAdditinalHeadersToEmptyRequestHeadersFromNetworkRequestAdapter() {
+        let mockRequestAdapter = MockNetworkRequestAdapter()
+        let additionalHeaders = ["headerKey1": "headerValue1",
+                                 "headerKey2": "headerValue2"]
+        mockRequestAdapter.additionalHeaders = additionalHeaders
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post)
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: mockRequestAdapter)
+            
+            XCTAssertEqual(urlRequest.allHTTPHeaderFields, additionalHeaders)
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testBuilderAddAdditinalHeadersToRequestHeadersFromNetworkRequestAdapter() {
+        let mockRequestAdapter = MockNetworkRequestAdapter()
+        let additionalHeaders = ["headerKey1": "headerValue1",
+                                 "headerKey2": "headerValue2"]
+        mockRequestAdapter.additionalHeaders = additionalHeaders
+        
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post,
+                                          parameters: ["param1Key": "param1Value"],
+                                          headers: ["headerKey3": "headerValue3"])
+        
+        let resultHeaders = ["headerKey1": "headerValue1",
+                             "headerKey2": "headerValue2",
+                             "headerKey3": "headerValue3",
+                             "Content-Type": "application/json"]
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: mockRequestAdapter)
+            
+            XCTAssertEqual(urlRequest.allHTTPHeaderFields, resultHeaders)
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testBuilderAddAdditinalParametersToRequestFromNetworkRequestAdapter() {
+        let mockRequestAdapter = MockNetworkRequestAdapter()
+        let additionalParameters: HTTPParameters = ["additionalParamKey1": "additionalParamValue1",
+                                                    "additionalParamKey2": false]
+        mockRequestAdapter.additionalParameters = additionalParameters
+        
+        let parameters: HTTPParameters = ["param1": true, "param2": "value2", "param3": 10]
+        let request = TestsNetworkRequest(path: ["test"],
+                                          httpMethod: .post,
+                                          parameters: parameters)
+        
+        let resultParameters: HTTPParameters = [
+            "param1": true,
+            "param2": "value2",
+            "param3": 10,
+            "additionalParamKey1": "additionalParamValue1",
+            "additionalParamKey2": false
+        ]
+        
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL,
+                                                         request: request,
+                                                         requestAdapter: mockRequestAdapter)
+            XCTAssertNotNil(urlRequest.httpBody, "urlRequest's httpBody can't be nil")
+            
+            let urlRequestBodyJSON = try? JSONSerialization.jsonObject(with: urlRequest.httpBody!,
+                                                                       options: []) as? [String: Any]
+            XCTAssertNotNil(urlRequestBodyJSON, "JSON from urlRequest's httpBody can't be nil")
+            
+            XCTAssertEqual(NSDictionary(dictionary: urlRequestBodyJSON!),
+                           NSDictionary(dictionary: resultParameters))
         } catch {
             XCTFail("URLRequest build failed with: \(error)")
         }

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientRequestBuilderTests.swift
@@ -1,0 +1,62 @@
+//
+//
+//  DefaultNetworkClientRequestBuilderTests.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+@testable import TinkoffASDKCore
+import XCTest
+
+class DefaultNetworkClientRequestBuilderTests: XCTestCase {
+    
+    let builder = DefaultNetworkClientRequestBuilder()
+    let baseURL = URL(string: "https://tinkoff.ru")!
+    
+    func testNoErrorBuildWithCorrectURLAndPath() {
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        XCTAssertNoThrow(try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil))
+    }
+    
+    func testBuildFailedWithErrorWithEmptyPath() {
+        let request = TestsNetworkRequest(path: [], httpMethod: .get)
+        XCTAssertThrowsError(try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil))
+    }
+
+    func testBuildCorrectUrlWithOneItemPath() {
+        let request = TestsNetworkRequest(path: ["test"], httpMethod: .get)
+        let resultURLString = "https://tinkoff.ru/test"
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
+            XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+    
+    func testBuildCorrectUrlWithThreeItemsPath() {
+        let request = TestsNetworkRequest(path: ["test", "url", "builder"], httpMethod: .get)
+        let resultURLString = "https://tinkoff.ru/test/url/builder"
+        do {
+            let urlRequest = try builder.buildURLRequest(baseURL: baseURL, request: request, requestAdapter: nil)
+            XCTAssertNotNil(urlRequest.url?.absoluteString, "URLRequest's url can't be nil")
+            XCTAssertEqual(urlRequest.url?.absoluteString, resultURLString)
+        } catch {
+            XCTFail("URLRequest build failed with: \(error)")
+        }
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientTests.swift
@@ -1,0 +1,77 @@
+//
+//
+//  DefaultNetworkClientTests.swift
+//
+//  Copyright (c) 2021 Tinkoff Bank
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+@testable import TinkoffASDKCore
+import XCTest
+
+class DefaultNetworkClientTests: XCTestCase {
+    
+    let url = URL(string: "https://tinkoff.ru")!
+    let urlRequestPerformer = MockRequestPerformer()
+    let requestBuilder = MockRequestBuilder()
+    let responseValidator = MockHTTPURLResponseValidator()
+    
+    lazy var networkClient = DefaultNetworkClient(urlRequestPerfomer: urlRequestPerformer,
+                                                  baseUrl: url,
+                                                  requestBuilder: requestBuilder,
+                                                  responseValidator: responseValidator)
+    
+    override func setUp() {
+        urlRequestPerformer.dataTaskMethodCalled = false
+        requestBuilder.buildURLRequestMethodCalled = false
+        responseValidator.validateMethodCalled = false
+    }
+
+    func testIfRequestBuilderBuildURLRequestMethodCalled() {
+        let request = TestsNetworkRequest(path: ["path"], httpMethod: .get)
+        networkClient.performRequest(request) { [requestBuilder] _ in
+            XCTAssertTrue(requestBuilder.buildURLRequestMethodCalled)
+        }
+    }
+    
+    func testIfURLRequestPerformerDataTaskMethodCalled() {
+        let request = TestsNetworkRequest(path: ["path"], httpMethod: .get)
+        networkClient.performRequest(request) { [urlRequestPerformer] _ in
+            XCTAssertTrue(urlRequestPerformer.dataTaskMethodCalled)
+        }
+    }
+    
+    func testIfValidatorNotCalledIfRequestWithTransportError() {
+        let request = TestsNetworkRequest(path: ["path"], httpMethod: .get)
+        
+        let error = NSError(domain: "domain", code: 666, userInfo: nil)
+        urlRequestPerformer.error = error
+        
+        networkClient.performRequest(request) { [responseValidator] _ in
+            XCTAssertFalse(responseValidator.validateMethodCalled)
+        }
+    }
+    
+    func testIfValidatorCalledIfRequestWithoutTransportErrorAndResponseNotNil() {
+        let request = TestsNetworkRequest(path: ["path"], httpMethod: .get)
+        
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+        urlRequestPerformer.urlResponse = response
+        
+        networkClient.performRequest(request) { [responseValidator] _ in
+            XCTAssertTrue(responseValidator.validateMethodCalled)
+        }
+    }
+}

--- a/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientTests.swift
+++ b/TinkoffASDKCore/TinkoffASDKCoreTests/Network/DefaultNetworkClientTests.swift
@@ -29,7 +29,7 @@ class DefaultNetworkClientTests: XCTestCase {
     let responseValidator = MockHTTPURLResponseValidator()
     
     lazy var networkClient = DefaultNetworkClient(urlRequestPerfomer: urlRequestPerformer,
-                                                  baseUrl: url,
+                                                  hostProvider: url,
                                                   requestBuilder: requestBuilder,
                                                   responseValidator: responseValidator)
     


### PR DESCRIPTION
Сетевой слой с покрытием тестами основных компонентов.

Интерфейсы основных компонентов:
`NetworkClient`
`URLRequestPerformer`
`NetworkClientRequestBuilder`
`HTTPURLResponseValidator`
`NetworkRequestAdapter`

Дефолтные реализации:
`DefaultNetworkClient`
`DefaultNetworkClientRequestBuilder`
`DefaultHTTPURLResponseValidator`
в качестве дефолтного `URLRequestPerformer` используется `URLSession`

Тесты для:
`DefaultNetworkClientRequestBuilder`
`DefaultHTTPURLResponseValidator`
`DefaultNetworkClient `
и есть "интеграционные" для `DefaultNetworkClient`, где подменяется только `URLRequestPerformer`.

![Untitled Diagram](https://user-images.githubusercontent.com/2726726/106907503-5f8a4680-670f-11eb-90bc-a3d8adc913bc.jpg)
